### PR TITLE
feat(config/seo): UTF-8 global + base de títulos y descripciones

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,8 @@
 	</scm>
 	<properties>
 		<java.version>17</java.version>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -119,6 +121,15 @@
 						</goals>
 					</execution>
 				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-resources-plugin</artifactId>
+				<version>3.3.1</version>
+				<configuration>
+					<encoding>UTF-8</encoding>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/src/main/java/com/devjobs/config/WebConfig.java
+++ b/src/main/java/com/devjobs/config/WebConfig.java
@@ -1,0 +1,15 @@
+package com.devjobs.config;
+
+import java.nio.charset.StandardCharsets;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.StringHttpMessageConverter;
+
+@Configuration
+public class WebConfig {
+
+  @Bean
+  public StringHttpMessageConverter stringHttpMessageConverter() {
+    return new StringHttpMessageConverter(StandardCharsets.UTF_8);
+  }
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -6,3 +6,15 @@ spring:
   jpa:
     hibernate:
       ddl-auto: none
+  thymeleaf:
+    encoding: UTF-8
+  messages:
+    encoding: UTF-8
+server:
+  servlet:
+    encoding:
+      charset: UTF-8
+      enabled: true
+      force: true
+  tomcat:
+    uri-encoding: UTF-8

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,7 +16,18 @@ spring:
     open-in-view: false
     properties:
       hibernate.format_sql: true
+  thymeleaf:
+    encoding: UTF-8
+  messages:
+    encoding: UTF-8
 management:
   endpoints.web.exposure.include: "health,info"
 server:
   port: 8080
+  servlet:
+    encoding:
+      charset: UTF-8
+      enabled: true
+      force: true
+  tomcat:
+    uri-encoding: UTF-8


### PR DESCRIPTION
- Forzado UTF-8 (Maven, Spring Boot, Thymeleaf y mensajes)
- Layout con fallback de <title> y <meta name="description">
- Helper SEO en JobWebController para setear título/descr. por vista
- OG y canonical listos para el siguiente paso de SEO